### PR TITLE
Fix building and add CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Build CGX
+on: [pull_request]
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: nvidia/cuda:12.6.3-devel-ubuntu24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: apt update && apt install -y libopenmpi-dev python3 python3.12-venv python3-dev
+      - name: Setup venv
+        shell: bash
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip3 install setuptools build ninja
+          pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+      - name: Run build
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          export NCCL_INCLUDE=/usr/include/
+          export NCCL_LIB=/usr/lib/
+          export MPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi/
+          python3 -m build --wheel --no-isolation

--- a/src/ProcessGroupCGX.h
+++ b/src/ProcessGroupCGX.h
@@ -261,6 +261,15 @@ public:
     register_backend(CGX_BACKEND_NAME, py::cpp_function(createProcessGroupCGX));
   }
 
+  // setting/getting group name is required for FSPD
+  const std::string& getGroupName() const override {
+      return name_;
+  }
+
+  void setGroupName(const std::string& name) override {
+      name_ = name;
+  }
+
   // Support float16 in MPI
   static MPI_Datatype float16_type;
 
@@ -280,6 +289,7 @@ protected:
           const std::shared_ptr<at::cuda::CUDAStream> stream = nullptr);
 
   bool stop_;
+  std::string name_;
 
   std::mutex pgMutex_;
   std::thread workerThread_;


### PR DESCRIPTION
This fixes the code so that it _builds_ again. Notable changes:
the location of `c10d::distributed` headers has changed, and `ProcessGroup::Work` is now `c10d::Work` 
There is the following warning tagged on to the work class, though:
> // Please do not use Work API, it is going away, to be
// replaced by ivalue::Future.
// Python binding for this class might change, please do not assume
// this will be bound using pybind.

Currently, it is used by pytorch's own `ProcessGroup`, so for now it probably is still fine. 


Second, this adds a github workflow that builds the library (though it doesn't check that the resulting artifact is actually useful...)