### PR TITLE
Code cleanup / modernization

### DIFF
--- a/src/ProcessGroupCGX.cc
+++ b/src/ProcessGroupCGX.cc
@@ -642,7 +642,7 @@ c10::intrusive_ptr<c10d::Work> ProcessGroupCGX::alltoall_base(
   checkSingleTensorHelper(inputTensor);
   checkSingleTensorHelper(outputTensor);
 
-  if (outputSplitSizes.size() == 0 && inputSplitSizes.size() == 0) {
+  if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
     // We can use alltoall
     TORCH_CHECK(outputTensor.numel() == inputTensor.numel() &&
                     outputTensor.type() == inputTensor.type(),

--- a/src/ProcessGroupCGX.cc
+++ b/src/ProcessGroupCGX.cc
@@ -321,7 +321,7 @@ void ProcessGroupCGX::runLoop() {
 c10::intrusive_ptr<c10d::Work> ProcessGroupCGX::enqueue(
     std::unique_ptr<WorkEntry> entry, const char *profilingTitle,
     const c10::optional<std::vector<at::Tensor>> &inputTensors, bool compressed,
-    const std::shared_ptr<at::cuda::CUDAStream> stream) {
+    const std::shared_ptr<at::cuda::CUDAStream>& stream) {
   auto work =
       c10::make_intrusive<WorkMPI>(entry->dst, profilingTitle, inputTensors,
                                    entry->endEvent_, compressed, stream);

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -19,8 +19,7 @@
 
 #include "buffer.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 PersistentBuffer::PersistentBuffer(size_t size) {
 //  tensor_ = at::empty(size, at::device(at::kCUDA).dtype(at::kByte));
 //  tensor_.zero_();
@@ -31,6 +30,4 @@ void * PersistentBuffer::RawPointer() const {
   return tensor_.data_ptr();
 }
 
-} // namespace common
-} // namespace cgx
-
+} // namespace cgx::common

--- a/src/common/buffer.h
+++ b/src/common/buffer.h
@@ -20,8 +20,7 @@
 #pragma once
 #include <torch/torch.h>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 struct PersistentBuffer {
   PersistentBuffer(size_t size);
@@ -31,5 +30,4 @@ private:
 };
 
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/buffer.h
+++ b/src/common/buffer.h
@@ -23,7 +23,7 @@
 namespace cgx::common {
 
 struct PersistentBuffer {
-  PersistentBuffer(size_t size);
+  explicit PersistentBuffer(size_t size);
   void* RawPointer() const;
 private:
   at::Tensor tensor_;

--- a/src/common/communicator.h
+++ b/src/common/communicator.h
@@ -21,14 +21,14 @@
 #include "common.h"
 #include "gpu_context.h"
 #include <mpi.h>
-
+#include <utility>
 
 namespace cgx::common {
 
 struct Communicator {
   enum CommunicatorType { MPI, SHM };
   Communicator(std::shared_ptr<GPUContext> gpu_context)
-      : gpu_context_(gpu_context) {}
+      : gpu_context_(std::move(gpu_context)) {}
   virtual void Init(int world_size, void *ctx) = 0;
   virtual void ISend(void *buf, size_t buf_size, int peer_rank,
                      gpuStream_t stream) = 0;
@@ -53,7 +53,7 @@ protected:
 
 struct CommunicatorLocal : Communicator {
   CommunicatorLocal(std::shared_ptr<GPUContext> gpu_context)
-      : Communicator(gpu_context) {}
+      : Communicator(std::move(gpu_context)) {}
   virtual void *GetRemoteBuftoSend(int peer_rank) = 0;
   virtual void *GetRemoteBuftoRecv(int peer_rank) = 0;
   virtual void *GetRemoteBroadcastBuftoSend() = 0;

--- a/src/common/communicator.h
+++ b/src/common/communicator.h
@@ -22,8 +22,8 @@
 #include "gpu_context.h"
 #include <mpi.h>
 
-namespace cgx {
-namespace common {
+
+namespace cgx::common {
 
 struct Communicator {
   enum CommunicatorType { MPI, SHM };
@@ -62,5 +62,4 @@ struct CommunicatorLocal : Communicator {
   virtual int TestRemote(int peer_rank, gpuStream_t stream) = 0;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/communicator.h
+++ b/src/common/communicator.h
@@ -27,7 +27,7 @@ namespace cgx::common {
 
 struct Communicator {
   enum CommunicatorType { MPI, SHM };
-  Communicator(std::shared_ptr<GPUContext> gpu_context)
+  explicit Communicator(std::shared_ptr<GPUContext> gpu_context)
       : gpu_context_(std::move(gpu_context)) {}
   virtual void Init(int world_size, void *ctx) = 0;
   virtual void ISend(void *buf, size_t buf_size, int peer_rank,
@@ -52,7 +52,7 @@ protected:
 };
 
 struct CommunicatorLocal : Communicator {
-  CommunicatorLocal(std::shared_ptr<GPUContext> gpu_context)
+  explicit CommunicatorLocal(std::shared_ptr<GPUContext> gpu_context)
       : Communicator(std::move(gpu_context)) {}
   virtual void *GetRemoteBuftoSend(int peer_rank) = 0;
   virtual void *GetRemoteBuftoRecv(int peer_rank) = 0;

--- a/src/common/compression/cuda_compression_operations.cu
+++ b/src/common/compression/cuda_compression_operations.cu
@@ -22,9 +22,8 @@
 #include "gpu_fp16_util.h"
 #include "gpu_rand.h"
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
+
 #if CUDA_VECTORIZED
 const bool VECTORIZE_COMPRESS = true;
 const bool VECTORIZE_DECOMPRESS = true;
@@ -831,6 +830,4 @@ template void CUDA_dequantize_maxmin<Half, false>(
     const unsigned char *input_data, unsigned char *output_data, int num_elems,
     int bits, int bucket_size, cudaStream_t stream);
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/cuda_compression_operations.h
+++ b/src/common/compression/cuda_compression_operations.h
@@ -20,9 +20,8 @@
 #pragma once
 #include "gpu_compression_operations.h"
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
+
 template<typename T>
 void CUDA_quantize_maxmin(const unsigned char *input_data, unsigned char *output_data,
                           unsigned char *feedback_data,
@@ -51,6 +50,4 @@ void CUDA_float2half(float *input,
                      int numel,
                      cudaStream_t stream);
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/gpu_compression_operations.cc
+++ b/src/common/compression/gpu_compression_operations.cc
@@ -24,9 +24,8 @@
 #elif HAVE_ROCM
 #include "hip_compression_operations.h"
 #endif
-namespace cgx {
-namespace common {
-namespace gpu {
+
+namespace cgx::common::gpu {
 
 size_t get_curand_array_size(int num_elems) {
   return BLOCKS_PER_GRID(num_elems, MAX_THREADS_PER_BLOCK)
@@ -156,6 +155,4 @@ void add<float>(int n,
 template
 void add<Half>(int n, const Half *x, Half *y, Half *sum, gpuStream_t stream);
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/gpu_compression_operations.h
+++ b/src/common/compression/gpu_compression_operations.h
@@ -30,9 +30,7 @@
 #include "../gpu_context.h"
 #include "gpu_def.h"
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
 
 constexpr int MIN(int a, int b) { return (a > b) ? b : a; }
 
@@ -67,6 +65,4 @@ void float2half(float* input, Half* output, int numel, gpuStream_t stream);
 
 size_t get_curand_array_size(int num_elems);
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/gpu_def.h
+++ b/src/common/compression/gpu_def.h
@@ -18,10 +18,9 @@
  */
 
 #pragma once
-namespace cgx {
-namespace common {
-namespace gpu {
 using uint64_t = unsigned long long int;
+
+namespace cgx::common::gpu {
 
 struct xorshift128p_state {
   uint64_t a, b;
@@ -87,6 +86,4 @@ struct TypeToVectorType<Half> {
   static const int num_values = 8;
 };
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/gpu_def.h
+++ b/src/common/compression/gpu_def.h
@@ -18,12 +18,12 @@
  */
 
 #pragma once
-using uint64_t = unsigned long long int;
+#include <cstdint>
 
 namespace cgx::common::gpu {
 
 struct xorshift128p_state {
-  uint64_t a, b;
+  std::uint64_t a, b;
 };
 
 using Half = __half;

--- a/src/common/compression/gpu_fp16_util.h
+++ b/src/common/compression/gpu_fp16_util.h
@@ -25,9 +25,7 @@
 #include <hip/hip_fp16.h>
 #endif
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
 
 
 __device__ __half hmax(__half a, __half b) { return __hge(a, b) ? a : b; }
@@ -227,5 +225,3 @@ __global__ void float2half(float* input, __half* output, int numel) {
 }
 
 } // namespace cuda
-} // namespace common
-} // namespace cgx

--- a/src/common/compression/gpu_rand.h
+++ b/src/common/compression/gpu_rand.h
@@ -17,9 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
 
 inline __device__ uint64_t splitmix64(uint64_t* seed) {
   uint64_t result = *seed;
@@ -60,6 +58,4 @@ __device__ float GetRand(RandState* state_p) {
 }
 
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/hip_compression_operations.cc
+++ b/src/common/compression/hip_compression_operations.cc
@@ -34,9 +34,7 @@
     }                                                                          \
   } while (0)
 
-namespace cgx {
-namespace common {
-namespace gpu {
+namespace cgx::common::gpu {
 const bool VECTORIZE_COMPRESS = false;
 const bool VECTORIZE_DECOMPRESS = false;
 
@@ -620,6 +618,4 @@ template void HIP_dequantize_maxmin<Half, false>(const unsigned char *input_data
                                                  int bucket_size,
                                                  hipStream_t stream);
 
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compression/hip_compression_operations.h
+++ b/src/common/compression/hip_compression_operations.h
@@ -20,10 +20,9 @@
 #pragma once
 #include "gpu_compression_operations.h"
 
-namespace cgx {
-namespace common {
-namespace gpu {
-template<typename T>
+namespace cgx::common::gpu {
+
+    template<typename T>
 void HIP_quantize_maxmin(const unsigned char *input_data, unsigned char *output_data,
                          unsigned char *feedback_data, int num_elems, int bits,
                          int bucket_size, RandState *states,
@@ -39,6 +38,4 @@ void HIP_add(int n, const T *x, T *y, T *sum, hipStream_t stream);
 
 void HIP_init_rand(RandState *states, size_t num_elems, unsigned int seed,
                    hipStream_t stream);
-} // namespace gpu
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::gpu

--- a/src/common/compressor.cc
+++ b/src/common/compressor.cc
@@ -437,7 +437,8 @@ void MaxMinQuantizer::Init(int element_size, gpuStream_t stream) {
                                                      metainfo_buf_size);
 #if !QSGD_DETERMENISTIC
     rand_states_ = static_cast<gpu::RandState *>(aux_buffer_->RawPointer());
-    gpu::init_rand_states(rand_states_, max_num_elems, time(NULL), stream);
+    // TODO allow setting a seed!
+    gpu::init_rand_states(rand_states_, max_num_elems, time(nullptr), stream);
 #endif
   }
 }

--- a/src/common/compressor.cc
+++ b/src/common/compressor.cc
@@ -18,6 +18,7 @@
  */
 
 #include "compressor.h"
+#include <utility>
 #include "common.h"
 #include "utils.h"
 
@@ -28,7 +29,7 @@ std::unordered_map<LayerId, CompressionLayerConfig, Compressor::hash_laierid>
 CompressionLayerConfig Compressor::default_config;
 
 Compressor::Compressor(std::shared_ptr<GPUContext> gpu_context)
-    : gpu_context_(gpu_context) {
+    : gpu_context_(std::move(gpu_context)) {
   unsigned int fusion_size_mb =
       utils::GetIntEnvOrDefault(FUSION_BUFFER_SIZE_MB, FUSION_SIZE_DEFAULT_MB);
   tensor_fusion_size_ = std::max(fusion_size_mb * 1024 * 1024, MIN_FUSION_SIZE);
@@ -252,7 +253,7 @@ bool DummyCompressor::isEnabled(const Layer &layer) {
 }
 
 Quantizer::Quantizer(std::shared_ptr<GPUContext> gpu_context)
-    : Compressor(gpu_context) {}
+    : Compressor(std::move(gpu_context)) {}
 
 void Quantizer::ResetParamsFromEnv() {
   Compressor::ResetParamsFromEnv();

--- a/src/common/compressor.cc
+++ b/src/common/compressor.cc
@@ -21,8 +21,7 @@
 #include "common.h"
 #include "utils.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 std::unordered_map<LayerId, CompressionLayerConfig, Compressor::hash_laierid>
     Compressor::layers_configs;
@@ -442,5 +441,4 @@ void MaxMinQuantizer::Init(int element_size, gpuStream_t stream) {
   }
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/compressor.h
+++ b/src/common/compressor.h
@@ -35,7 +35,7 @@ struct CompressionLayerConfig {
   int quantization_bits;
   int bucket_size;
   bool skip_incomplete_buckets;
-  bool operator==(const CompressionLayerConfig &b) {
+  bool operator==(const CompressionLayerConfig &b) const {
     return quantization_bits == b.quantization_bits and
            bucket_size == b.bucket_size and
            skip_incomplete_buckets == b.skip_incomplete_buckets;

--- a/src/common/compressor.h
+++ b/src/common/compressor.h
@@ -44,7 +44,7 @@ struct CompressionLayerConfig {
 
 class Compressor {
 public:
-  Compressor(std::shared_ptr<GPUContext> gpu_context);
+  explicit Compressor(std::shared_ptr<GPUContext> gpu_context);
   virtual ~Compressor() = default;
   // Returns size of buffer to allocate for usage in compress (in bytes). We
   // assume that no compression will be done in-place.
@@ -144,7 +144,7 @@ protected:
 
 class DummyCompressor : public Compressor {
 public:
-  DummyCompressor(std::shared_ptr<GPUContext> gpu_context)
+  explicit DummyCompressor(std::shared_ptr<GPUContext> gpu_context)
       : Compressor(std::move(gpu_context)) {}
 
   size_t CompressBuffer(unsigned char *input, unsigned char *output,
@@ -163,7 +163,7 @@ public:
 
 class MaxMinQuantizer : public Quantizer {
 public:
-  MaxMinQuantizer(std::shared_ptr<GPUContext> gpu_context)
+  explicit MaxMinQuantizer(std::shared_ptr<GPUContext> gpu_context)
       : Quantizer(std::move(gpu_context)) {}
 
   size_t CompressBuffer(unsigned char *input, unsigned char *output,

--- a/src/common/compressor.h
+++ b/src/common/compressor.h
@@ -27,8 +27,7 @@
 #include "gpu_context.h"
 #include "layer.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 const int COMPRESSION_DEFAULT_BUCKET_SIZE = 512;
 
 struct CompressionLayerConfig {
@@ -181,5 +180,4 @@ public:
   virtual void Init(int elem_size, gpuStream_t stream);
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/compressor.h
+++ b/src/common/compressor.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 #include "buffer.h"
 #include "compression/gpu_compression_operations.h"
@@ -144,7 +145,7 @@ protected:
 class DummyCompressor : public Compressor {
 public:
   DummyCompressor(std::shared_ptr<GPUContext> gpu_context)
-      : Compressor(gpu_context) {}
+      : Compressor(std::move(gpu_context)) {}
 
   size_t CompressBuffer(unsigned char *input, unsigned char *output,
                         unsigned char *feedback, int num_elems,
@@ -163,7 +164,7 @@ public:
 class MaxMinQuantizer : public Quantizer {
 public:
   MaxMinQuantizer(std::shared_ptr<GPUContext> gpu_context)
-      : Quantizer(gpu_context) {}
+      : Quantizer(std::move(gpu_context)) {}
 
   size_t CompressBuffer(unsigned char *input, unsigned char *output,
                         unsigned char *feedback, int num_elems,
@@ -177,7 +178,7 @@ public:
   size_t BufferSize(int num_elems, size_t element_size,
                     const CompressionLayerConfig &config) final;
   bool isEnabled(const Layer &tensor) override;
-  virtual void Init(int elem_size, gpuStream_t stream);
+  void Init(int elem_size, gpuStream_t stream) override;
 };
 
 } // namespace cgx::common

--- a/src/common/cuda_operations.cc
+++ b/src/common/cuda_operations.cc
@@ -19,8 +19,7 @@
 
 #include <thread>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class GPUContext::impl {
 public:
@@ -139,5 +138,4 @@ private:
 
 #include "gpu_context_impl.cc"
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/cuda_operations.cc
+++ b/src/common/cuda_operations.cc
@@ -23,7 +23,7 @@ namespace cgx::common {
 
 class GPUContext::impl {
 public:
-  void ErrorCheck(std::string op_name, cudaError_t cuda_result) {
+  void ErrorCheck(const char* op_name, cudaError_t cuda_result) {
     if (cuda_result != cudaSuccess) {
       throw std::logic_error(
           std::string(op_name) + " failed: " + cudaGetErrorString(cuda_result));

--- a/src/common/gpu_context.h
+++ b/src/common/gpu_context.h
@@ -62,8 +62,7 @@ using gpuIpcEventHandle_t = hipIpcEventHandle_t;
 #include <torch/torch.h>
 #endif
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class GPUContext {
 public:
@@ -99,5 +98,4 @@ private:
   class impl;
   std::unique_ptr<impl> pimpl;
 };
-} // namespace common
-}// namespace cgx
+} // namespace cgx::common

--- a/src/common/gpu_context.h
+++ b/src/common/gpu_context.h
@@ -69,7 +69,7 @@ public:
   GPUContext();
   ~GPUContext();
 
-  void ErrorCheck(std::string op_name, gpuError_t gpu_result);
+  void ErrorCheck(const char* op_name, gpuError_t gpu_result);
 
   void EventCreate(gpuEvent_t* event);
   void EventDestroy(gpuEvent_t& event);

--- a/src/common/gpu_context_impl.cc
+++ b/src/common/gpu_context_impl.cc
@@ -21,7 +21,7 @@
 GPUContext::GPUContext() : pimpl{new impl} {}
 GPUContext::~GPUContext() = default;
 
-void GPUContext::ErrorCheck(std::string op_name, gpuError_t gpu_result) {
+void GPUContext::ErrorCheck(const char* op_name, gpuError_t gpu_result) {
   pimpl->ErrorCheck(op_name, gpu_result);
 }
 

--- a/src/common/hip_operations.cc
+++ b/src/common/hip_operations.cc
@@ -17,7 +17,7 @@
 
 #include "gpu_context.h"
 
-#include <thread>
+#include <mutex>
 
 namespace cgx::common {
 

--- a/src/common/hip_operations.cc
+++ b/src/common/hip_operations.cc
@@ -23,7 +23,7 @@ namespace cgx::common {
 
 class GPUContext::impl {
 public:
-  void ErrorCheck(std::string op_name, hipError_t hip_result) {
+  void ErrorCheck(const char* op_name, hipError_t hip_result) {
     if (hip_result != hipSuccess) {
       throw std::logic_error(
           std::string(op_name) + " failed: " + hipGetErrorString(hip_result));

--- a/src/common/hip_operations.cc
+++ b/src/common/hip_operations.cc
@@ -18,8 +18,8 @@
 #include "gpu_context.h"
 
 #include <thread>
-namespace cgx {
-namespace common {
+
+namespace cgx::common {
 
 class GPUContext::impl {
 public:
@@ -128,6 +128,4 @@ private:
 
 #include "gpu_context_impl.cc"
 
-} // namespace common
-} // namespace cgx
-
+} // namespace cgx::common

--- a/src/common/hip_operations.cc
+++ b/src/common/hip_operations.cc
@@ -58,7 +58,7 @@ public:
   void StreamCreate(hipStream_t *stream) {
     int greatest_priority;
     ErrorCheck("hipDeviceGetStreamPriorityRange",
-               hipDeviceGetStreamPriorityRange(NULL, &greatest_priority));
+               hipDeviceGetStreamPriorityRange(nullptr, &greatest_priority));
     ErrorCheck("hipStreamCreateWithPriority",
                hipStreamCreateWithPriority(stream,
                                            hipStreamNonBlocking,

--- a/src/common/layer.cc
+++ b/src/common/layer.cc
@@ -19,8 +19,7 @@
 
 #include "layer.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 Layer::Layer(const at::Tensor &tensor) {
   data_ = tensor.data_ptr();
@@ -41,5 +40,4 @@ Layer::Layer(const at::Tensor &tensor, const LayerId &layer_id,
   device_index_ = tensor.get_device();
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/layer.h
+++ b/src/common/layer.h
@@ -26,7 +26,7 @@ namespace cgx::common {
 using LayerId = std::pair<unsigned, unsigned>;
 
 struct Layer {
-  Layer(const at::Tensor& tensor);
+  explicit Layer(const at::Tensor& tensor);
   Layer(const at::Tensor& tensor, const LayerId& layer_id,
         void* ptr, int numel);
   const LayerId& layer_id() const {return layer_id_;}

--- a/src/common/layer.h
+++ b/src/common/layer.h
@@ -22,8 +22,7 @@
 #include <torch/torch.h>
 #include <utility>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 using LayerId = std::pair<unsigned, unsigned>;
 
 struct Layer {
@@ -45,5 +44,5 @@ private:
   int64_t device_index_;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common
+

--- a/src/common/mpi_communicator.cc
+++ b/src/common/mpi_communicator.cc
@@ -22,7 +22,7 @@
 namespace cgx::common {
 
 void MPICommunicator::Init(int world_size, void *ctx) {
-  if (recv_requests.size() == 0) {
+  if (recv_requests.empty()) {
     for (int i = 0; i < world_size; i++) {
       recv_requests.push_back(MPI_REQUEST_NULL);
       send_requests.push_back(MPI_REQUEST_NULL);

--- a/src/common/mpi_communicator.cc
+++ b/src/common/mpi_communicator.cc
@@ -19,8 +19,7 @@
 
 #include "mpi_communicator.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 void MPICommunicator::Init(int world_size, void *ctx) {
   if (recv_requests.size() == 0) {
@@ -84,5 +83,5 @@ void MPICommunicator::WaitAllRecv() {
   }
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common
+

--- a/src/common/mpi_communicator.h
+++ b/src/common/mpi_communicator.h
@@ -20,8 +20,7 @@
 #pragma once
 #include "communicator.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 struct MPICommunicator : public Communicator {
   MPICommunicator(std::shared_ptr<GPUContext>gpu_context) : Communicator(gpu_context){
@@ -42,5 +41,4 @@ protected:
   std::vector<MPI_Request> recv_requests;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/mpi_communicator.h
+++ b/src/common/mpi_communicator.h
@@ -24,19 +24,19 @@
 namespace cgx::common {
 
 struct MPICommunicator : public Communicator {
-  MPICommunicator(std::shared_ptr<GPUContext> gpu_context) : Communicator(std::move(gpu_context)){
+  explicit MPICommunicator(std::shared_ptr<GPUContext> gpu_context) : Communicator(std::move(gpu_context)){
     communicator_type_ = CommunicatorType::MPI;
   }
-  virtual void Init(int world_size, void *ctx) override;
-  virtual void ISend(void *buf, size_t buf_size, int peer_rank,
-                     gpuStream_t stream) override;
-  virtual void IRecv(void *buf, size_t buf_size, int peer_rank,
-                     gpuStream_t stream) override;
-  virtual void WaitSend(int peer_rank) override;
-  virtual void WaitRecv(int peer_rank) override;
-  virtual void WaitAllSend() override;
-  virtual void WaitAllRecv() override;
-  virtual int TestRecv(int rank) override;
+  void Init(int world_size, void *ctx) override;
+  void ISend(void *buf, size_t buf_size, int peer_rank,
+             gpuStream_t stream) override;
+  void IRecv(void *buf, size_t buf_size, int peer_rank,
+             gpuStream_t stream) override;
+  void WaitSend(int peer_rank) override;
+  void WaitRecv(int peer_rank) override;
+  void WaitAllSend() override;
+  void WaitAllRecv() override;
+  int TestRecv(int rank) override;
 protected:
   std::vector<MPI_Request> send_requests;
   std::vector<MPI_Request> recv_requests;

--- a/src/common/mpi_communicator.h
+++ b/src/common/mpi_communicator.h
@@ -19,11 +19,12 @@
 
 #pragma once
 #include "communicator.h"
+#include <utility>
 
 namespace cgx::common {
 
 struct MPICommunicator : public Communicator {
-  MPICommunicator(std::shared_ptr<GPUContext>gpu_context) : Communicator(gpu_context){
+  MPICommunicator(std::shared_ptr<GPUContext> gpu_context) : Communicator(std::move(gpu_context)){
     communicator_type_ = CommunicatorType::MPI;
   }
   virtual void Init(int world_size, void *ctx) override;

--- a/src/common/mpi_context.cc
+++ b/src/common/mpi_context.cc
@@ -20,8 +20,7 @@
 #include "mpi_context.h"
 #include "common.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 MPIContext::MPIContext() {
   MPI_CHECK(MPI_Comm_dup(MPI_COMM_WORLD, &global_comm_));
@@ -51,5 +50,4 @@ void MPIContext::Barrier(MPI_Comm comm) const {
   MPI_CHECK(MPI_Barrier(comm));
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/mpi_context.h
+++ b/src/common/mpi_context.h
@@ -20,8 +20,7 @@
 #pragma once
 #include <mpi.h>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 struct MPIContext {
   MPIContext();
@@ -37,7 +36,4 @@ private:
   MPI_Comm cross_comm_;
 };
 
-} // namespace common
-} // namespace cgx
-
-
+} // namespace cgx::common

--- a/src/common/nccl_reduce.cc
+++ b/src/common/nccl_reduce.cc
@@ -19,6 +19,7 @@
 
 #include "nccl_reduce.h"
 #include <map>
+#include <utility>
 
 namespace cgx::common {
 
@@ -29,7 +30,7 @@ std::map<at::ScalarType, ncclDataType_t> ncclDatatype = {
 
 NCCL_Reduce::NCCL_Reduce(std::shared_ptr<GPUContext> gpu_context,
                          std::shared_ptr<Compressor> compressor, int world_size)
-    : Reducer(gpu_context, compressor) {
+    : Reducer(std::move(gpu_context), std::move(compressor)) {
   nccl_comm_ = nullptr;
   int64_t chunk_size = tensor_fusion_size_;
   chunk_size = utils::aligned_size((chunk_size + world_size - 1) / world_size);

--- a/src/common/nccl_reduce.cc
+++ b/src/common/nccl_reduce.cc
@@ -41,7 +41,7 @@ NCCL_Reduce::NCCL_Reduce(std::shared_ptr<GPUContext> gpu_context,
   gradients_recv_ = gradients_send_ + chunk_size * world_size;
 }
 
-void NCCL_Reduce::ErrorCheck(std::string op_name, ncclResult_t nccl_result) {
+void NCCL_Reduce::ErrorCheck(const char* op_name, ncclResult_t nccl_result) {
   if (nccl_result != ncclSuccess) {
     ncclCommAbort(nccl_comm_);
     throw std::runtime_error(std::string(op_name) +

--- a/src/common/nccl_reduce.cc
+++ b/src/common/nccl_reduce.cc
@@ -20,8 +20,7 @@
 #include "nccl_reduce.h"
 #include <map>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 std::map<at::ScalarType, ncclDataType_t> ncclDatatype = {
     {at::kByte, ncclInt8},   {at::kChar, ncclChar}, {at::kDouble, ncclFloat64},
@@ -244,5 +243,4 @@ void NCCL_Reduce::UnfuseLayerData(unsigned char *layers_data,
   }
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/nccl_reduce.h
+++ b/src/common/nccl_reduce.h
@@ -39,7 +39,7 @@ public:
 
 private:
   void Init(void *comm);
-  void ErrorCheck(std::string op_name, ncclResult_t nccl_result);
+  void ErrorCheck(const char* op_name, ncclResult_t nccl_result);
   void FuseLayerData(unsigned char **layers_data, std::vector<Layer> &layers,
                      int num_elements, int global_offset, gpuStream_t stream);
   void UnfuseLayerData(unsigned char *layers_data, std::vector<Layer> &layers,

--- a/src/common/nccl_reduce.h
+++ b/src/common/nccl_reduce.h
@@ -21,8 +21,7 @@
 #include "reducer.h"
 #include <nccl.h>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class NCCL_Reduce : public Reducer {
 public:
@@ -57,5 +56,4 @@ private:
   ncclComm_t nccl_comm_;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/reducer.cc
+++ b/src/common/reducer.cc
@@ -18,8 +18,7 @@
  */
 
 #include "reducer.h"
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 Reducer::Reducer(std::shared_ptr<GPUContext> gpu_context,
                  std::shared_ptr<Compressor> compressor,
@@ -69,7 +68,7 @@ int Reducer::AllReduceAlltoAll(int num_elements, int global_offset,
   }
   communicator_->WaitAllSend();
 
-  while (nodes.size() > 0) {
+  while (!nodes.empty()) {
     for (int i = 0; i < nodes.size(); i++) {
       auto &node_rank = nodes.at(i);
       if (communicator_->TestRecv(node_rank) > 0) {
@@ -158,5 +157,4 @@ int Reducer::Broadcast(int num_elements, int global_offset,
   return 0;
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/reducer.cc
+++ b/src/common/reducer.cc
@@ -18,13 +18,15 @@
  */
 
 #include "reducer.h"
+#include <utility>
+
 namespace cgx::common {
 
 Reducer::Reducer(std::shared_ptr<GPUContext> gpu_context,
                  std::shared_ptr<Compressor> compressor,
                  std::shared_ptr<Communicator> communicator)
-    : compressor_(compressor), gpu_context_(gpu_context),
-      communicator_(communicator) {
+    : compressor_(std::move(compressor)), gpu_context_(std::move(gpu_context)),
+      communicator_(std::move(communicator)) {
   unsigned int fusion_size_mb =
       utils::GetIntEnvOrDefault(FUSION_BUFFER_SIZE_MB, FUSION_SIZE_DEFAULT_MB);
   tensor_fusion_size_ = std::max(fusion_size_mb * 1024 * 1024, MIN_FUSION_SIZE);

--- a/src/common/reducer.h
+++ b/src/common/reducer.h
@@ -30,8 +30,7 @@
 #include "shm_communicator.h"
 #endif
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class Reducer {
 public:
@@ -73,5 +72,4 @@ public:
 };
 
 void printDebug(unsigned char *buf, int numel);
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/reducer.h
+++ b/src/common/reducer.h
@@ -24,6 +24,7 @@
 #include "gpu_context.h"
 #include "utils.h"
 #include <mpi.h>
+#include <utility>
 
 #include "mpi_communicator.h"
 #if HAVE_CUDA
@@ -68,7 +69,7 @@ public:
   MPIReducer(std::shared_ptr<common::GPUContext> gpu_context,
              std::shared_ptr<Compressor> compressor,
              std::shared_ptr<Communicator> communicator)
-      : Reducer(gpu_context, compressor, communicator) {}
+      : Reducer(std::move(gpu_context), std::move(compressor), std::move(communicator)) {}
 };
 
 void printDebug(unsigned char *buf, int numel);

--- a/src/common/ring.cc
+++ b/src/common/ring.cc
@@ -18,6 +18,7 @@
  */
 
 #include "ring.h"
+#include <utility>
 
 namespace cgx::common {
 
@@ -25,7 +26,7 @@ MPI_Allreduce_Ring::MPI_Allreduce_Ring(
     std::shared_ptr<common::GPUContext> gpu_context,
     std::shared_ptr<Compressor> compressor,
     std::shared_ptr<Communicator> communicator, int world_size)
-    : MPIReducer(gpu_context, compressor, communicator) {
+    : MPIReducer(std::move(gpu_context), std::move(compressor), std::move(communicator)) {
   int64_t chunk_size = tensor_fusion_size_;
   chunk_size = utils::aligned_size((chunk_size + world_size - 1) / world_size);
   int64_t buffer_size = chunk_size * world_size + chunk_size * (world_size - 1);

--- a/src/common/ring.cc
+++ b/src/common/ring.cc
@@ -19,8 +19,7 @@
 
 #include "ring.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 MPI_Allreduce_Ring::MPI_Allreduce_Ring(
     std::shared_ptr<common::GPUContext> gpu_context,
@@ -225,5 +224,4 @@ int MPI_Allreduce_Ring::AllreduceDivisionCompressed(int num_elements,
   return 0;
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/ring.h
+++ b/src/common/ring.h
@@ -21,8 +21,7 @@
 
 #include "reducer.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class MPI_Allreduce_Ring : public MPIReducer {
 public:
@@ -44,5 +43,4 @@ private:
                                     gpuStream_t gpu_stream);
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/scatter_reduce_allgather.cc
+++ b/src/common/scatter_reduce_allgather.cc
@@ -20,6 +20,7 @@
 #include "scatter_reduce_allgather.h"
 
 #include "assert.h"
+#include <utility>
 #include "compression/gpu_common.h"
 
 namespace cgx::common {
@@ -40,7 +41,7 @@ MPI_Allreduce_ScatterReduceAllgather::MPI_Allreduce_ScatterReduceAllgather(
     std::shared_ptr<GPUContext> gpu_context,
     std::shared_ptr<Compressor> compressor,
     std::shared_ptr<Communicator> communicator, int world_size)
-    : MPIReducer(gpu_context, compressor, communicator) {
+    : MPIReducer(std::move(gpu_context), std::move(compressor), std::move(communicator)) {
   int64_t chunk_size = tensor_fusion_size_;
   all_to_all_reduction_ =
       utils::GetIntEnvOrDefault(DEBUG_ALL_TO_ALL_REDUCTION, 0);

--- a/src/common/scatter_reduce_allgather.cc
+++ b/src/common/scatter_reduce_allgather.cc
@@ -22,8 +22,7 @@
 #include "assert.h"
 #include "compression/gpu_common.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 void printDebug(void *buf, int numel, gpuStream_t gpu_stream) {
   float *host_buf = new float[numel];
@@ -412,5 +411,4 @@ int MPI_Allreduce_ScatterReduceAllgather::AllreduceUncompressed(
   return 0;
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/scatter_reduce_allgather.cc
+++ b/src/common/scatter_reduce_allgather.cc
@@ -140,7 +140,7 @@ int MPI_Allreduce_ScatterReduceAllgather::AllreduceCompressed(
     send_sizes.pop();
     nodes.push_back(node_rank);
   }
-  while (nodes.size() > 0) {
+  while (!nodes.empty()) {
     for (int i = 0; i < nodes.size(); i++) {
       auto &node_rank = nodes.at(i);
       if (communicator_->TestRecv(node_rank) > 0) {
@@ -183,7 +183,7 @@ int MPI_Allreduce_ScatterReduceAllgather::AllreduceCompressed(
     nodes.push_back(node_rank);
   }
   int their_start_offset;
-  while (nodes.size() > 0) {
+  while (!nodes.empty()) {
     for (int i = 0; i < nodes.size(); i++) {
       auto &node_rank = nodes.at(i);
       if (communicator_->TestRecv(node_rank) > 0) {
@@ -291,7 +291,7 @@ int MPI_Allreduce_ScatterReduceAllgather::AllReduceAlltoAllCompressed(
   communicator_->WaitAllSend();
   compressor_->Decompress(gradients_send_, layers, global_offset, num_elements,
                           false, gpu_stream);
-  while (nodes.size() > 0) {
+  while (!nodes.empty()) {
     for (int i = 0; i < nodes.size(); i++) {
       auto &node_rank = nodes.at(i);
       if (communicator_->TestRecv(node_rank) > 0) {
@@ -353,7 +353,7 @@ int MPI_Allreduce_ScatterReduceAllgather::AllreduceUncompressed(
     }
     send_buf = send_buf_base + offsets[rank] * element_size;
     recv_buf = gradients_recv_;
-    while (nodes.size() > 0) {
+    while (!nodes.empty()) {
       for (int i = 0; i < nodes.size(); i++) {
         auto &node_rank = nodes[i];
         if (communicator_->TestRecv(node_rank) > 0) {

--- a/src/common/scatter_reduce_allgather.h
+++ b/src/common/scatter_reduce_allgather.h
@@ -21,8 +21,7 @@
 #include "reducer.h"
 #include "communicator.h"
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 class MPI_Allreduce_ScatterReduceAllgather : public MPIReducer {
 public:
@@ -55,5 +54,4 @@ private:
   unsigned counter_ = 0;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/shm_communicator.cc
+++ b/src/common/shm_communicator.cc
@@ -189,7 +189,7 @@ void SHMCommunicator::WaitAllRecv() {
       continue;
     nodes.push_back(peer_rank);
   }
-  while (nodes.size() > 0) {
+  while (!nodes.empty()) {
     for (int i = 0; i < nodes.size(); i++) {
       if (TestRecv(nodes[i])) {
         nodes.erase(nodes.begin() + i);

--- a/src/common/shm_communicator.cc
+++ b/src/common/shm_communicator.cc
@@ -21,8 +21,7 @@
     }                                                                          \
   } while (0)
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 
 const char *sendSemFmt = "/cgx-sem-send-%d-%d";
 const char *recvSemFmt = "/cgx-sem-recv-%d-%d";
@@ -353,5 +352,4 @@ void SHMCommunicator::unlinkSem(int peer_rank) {
   TRIV_CHECK(sem_unlink(semName));
 }
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/shm_communicator.h
+++ b/src/common/shm_communicator.h
@@ -24,8 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace cgx {
-namespace common {
+namespace cgx::common {
 struct SHMCommunicator : public CommunicatorLocal {
   SHMCommunicator(std::shared_ptr<GPUContext> gpu_context)
       : CommunicatorLocal(gpu_context) {
@@ -100,5 +99,4 @@ private:
   bool initialized_ = false;
 };
 
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common

--- a/src/common/shm_communicator.h
+++ b/src/common/shm_communicator.h
@@ -22,12 +22,13 @@
 #include "communicator.h"
 #include <semaphore.h>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace cgx::common {
 struct SHMCommunicator : public CommunicatorLocal {
   SHMCommunicator(std::shared_ptr<GPUContext> gpu_context)
-      : CommunicatorLocal(gpu_context) {
+      : CommunicatorLocal(std::move(gpu_context)) {
     communicator_type_ = CommunicatorType::SHM;
   }
 

--- a/src/common/shm_communicator.h
+++ b/src/common/shm_communicator.h
@@ -27,29 +27,29 @@
 
 namespace cgx::common {
 struct SHMCommunicator : public CommunicatorLocal {
-  SHMCommunicator(std::shared_ptr<GPUContext> gpu_context)
+  explicit SHMCommunicator(std::shared_ptr<GPUContext> gpu_context)
       : CommunicatorLocal(std::move(gpu_context)) {
     communicator_type_ = CommunicatorType::SHM;
   }
 
   ~SHMCommunicator();
 
-  virtual void Init(int world_size, void *ctx) override;
-  virtual void ISend(void *buf, size_t buf_size, int peer_rank,
-                     gpuStream_t stream) override;
-  virtual void IRecv(void *buf, size_t buf_size, int peer_rank,
-                     gpuStream_t stream) override;
-  virtual void WaitSend(int rank) override;
-  virtual void WaitRecv(int rank) override;
-  virtual void WaitAllSend() override;
-  virtual void WaitAllRecv() override;
-  virtual int TestRecv(int rank) override;
-  virtual void *GetRemoteBuftoSend(int peer_rank) override;
-  virtual void *GetRemoteBuftoRecv(int peer_rank) override;
-  virtual void *GetRemoteBroadcastBuftoSend() override;
-  virtual void *GetRemoteBroadcastBuftoRecv(int peer_rank) override;
-  virtual void CommitSend(int peer_rank, gpuStream_t stream) override;
-  virtual int TestRemote(int peer_rank, gpuStream_t stream) override;
+  void Init(int world_size, void *ctx) override;
+  void ISend(void *buf, size_t buf_size, int peer_rank,
+             gpuStream_t stream) override;
+  void IRecv(void *buf, size_t buf_size, int peer_rank,
+             gpuStream_t stream) override;
+  void WaitSend(int rank) override;
+  void WaitRecv(int rank) override;
+  void WaitAllSend() override;
+  void WaitAllRecv() override;
+  int TestRecv(int rank) override;
+  void *GetRemoteBuftoSend(int peer_rank) override;
+  void *GetRemoteBuftoRecv(int peer_rank) override;
+  void *GetRemoteBroadcastBuftoSend() override;
+  void *GetRemoteBroadcastBuftoRecv(int peer_rank) override;
+  void CommitSend(int peer_rank, gpuStream_t stream) override;
+  int TestRemote(int peer_rank, gpuStream_t stream) override;
 
 private:
   struct gpuEventSync {

--- a/src/common/shm_utils.cc
+++ b/src/common/shm_utils.cc
@@ -60,7 +60,7 @@ int shm_allocate(int fd, const int shmsize) {
 }
 
 int shm_map(int fd, const int shmsize, void **ptr) {
-  *ptr = mmap(NULL, shmsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  *ptr = mmap(nullptr, shmsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   return (*ptr == MAP_FAILED) ? -1 : 0;
 }
 
@@ -110,12 +110,12 @@ gpuError:
     shm_unlink(shmname);
   if (ptr != MAP_FAILED)
     munmap(ptr, shmsize);
-  *shmPtr = NULL;
+  *shmPtr = nullptr;
   return res;
 }
 
 int shmUnlink(const char *shmname) {
-  if (shmname != NULL)
+  if (shmname != nullptr)
     SYS_CHECK(shm_unlink(shmname), "shm_unlink");
   return 0;
 }

--- a/src/common/shm_utils.cc
+++ b/src/common/shm_utils.cc
@@ -48,10 +48,7 @@
   } while (false)
 
 
-namespace cgx {
-namespace common {
-namespace utils {
-
+namespace cgx::common::utils {
 
 int shm_allocate(int fd, const int shmsize) {
   int err = posix_fallocate(fd, 0, shmsize);
@@ -136,7 +133,4 @@ int shmClose(void *shmPtr, void *devShmPtr, const int shmsize) {
   return 0;
 }
 
-} // namespace utils
-} // namespace common
-} // namespace cgx
-
+} // namespace cgx::common::utils

--- a/src/common/shm_utils.h
+++ b/src/common/shm_utils.h
@@ -19,9 +19,7 @@
 
 #pragma once
 
-namespace cgx {
-namespace common {
-namespace utils {
+namespace cgx::common::utils {
 const int MAX_SHM_NAME_LEN = 1024;
 
 int shmOpen(const char *shmname, const int shmsize, void **shmPtr,
@@ -31,6 +29,4 @@ int shmUnlink(const char *shmname);
 
 int shmClose(void *shmPtr, void *devShmPtr, const int shmsize);
 
-} // namespace utils
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::utils

--- a/src/common/utils.cc
+++ b/src/common/utils.cc
@@ -20,9 +20,7 @@
 #include "utils.h"
 #include <string>
 
-namespace cgx {
-namespace common {
-namespace utils {
+namespace cgx::common::utils {
 
 int GetIntEnvOrDefault(const char *env_variable, int default_value) {
   auto env_value = std::getenv(env_variable);
@@ -92,6 +90,4 @@ size_t aligned_size(size_t size) {
   return round_to(size, ALIGNMENT_UNIT);
 }
 
-} // namespace utils
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::utils

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -25,9 +25,7 @@
 #include <torch/torch.h>
 #endif
 
-namespace cgx {
-namespace common {
-namespace utils {
+namespace cgx::common::utils {
 
 enum CommunicatorType {
   MPI,
@@ -58,6 +56,4 @@ size_t aligned_size(size_t size);
 CommunicatorType GetCommTypeFromEnv(const char* env, CommunicatorType default_value);
 ReductionType GetRedTypeFromEnv(const char* env, ReductionType default_value);
 
-} // namespace utils
-} // namespace common
-} // namespace cgx
+} // namespace cgx::common::utils

--- a/src/mpi_allreduce_operations.h
+++ b/src/mpi_allreduce_operations.h
@@ -39,7 +39,7 @@ struct MPIAllReduce_Operation {
                             int quantization_bits, int bucket_size) {
     assert(layers_sizes_.size() >= bucket_idx && "Registering bucket out of order is not supported");
     if (layers_sizes_.size() == bucket_idx) {
-      layers_sizes_.emplace_back(std::vector<unsigned>());
+      layers_sizes_.emplace_back();
     }
     assert(layers_sizes_[bucket_idx].size() >= layer_idx && "Registering layer out of order is not supported");
     layers_sizes_[bucket_idx].push_back(layer_numel);

--- a/src/new/chunk_cat_compress.h
+++ b/src/new/chunk_cat_compress.h
@@ -1,0 +1,14 @@
+#include <torch/torch.h>
+
+#ifndef TORCH_CGX_CHUNK_CAT_COMPRESS_H
+#define TORCH_CGX_CHUNK_CAT_COMPRESS_H
+
+// torch.ops.fsdp.chunk_cat(
+//        unsharded_grads, dim=0, num_chunks=world_size, out=reduce_scatter_input
+//    )
+
+void chunk_cat_compress(const std::vector<at::Tensor>& inputs, at::Tensor& output, at::Tensor& meta) {
+
+}
+
+#endif //TORCH_CGX_CHUNK_CAT_COMPRESS_H


### PR DESCRIPTION
* use nested namespace specifications
* std::move instead of copying shared_ptr
* nullptr, explicit, override
* use const char* instead of std::string to decrease cost of error checking happy path.